### PR TITLE
Fix convertPhone()

### DIFF
--- a/server/contacts/contactController.js
+++ b/server/contacts/contactController.js
@@ -15,14 +15,7 @@ module.exports = {
       if (typeof phone === 'number') {
         return phone;
       }
-      var phoneArray = phone.split('');
-      var phoneNum = [];
-      for (var i = 0; i < phoneArray.length; i++) {
-        if (!isNaN(phoneArray[i])) {
-          phoneNum.push(phoneArray[i]);
-        }
-      }
-      return Number(phoneNum.join(''));
+      return Number(phone.replace(/\D/g, ''));
     };
 
     // map array of contacts received in request to new objects 
@@ -57,9 +50,9 @@ module.exports = {
       Contact.create(newContacts, function (error, docs) {
         if (error) {
           console.log(error);
-          response.status(500).send('Error: Could not save contacts');
+          response.status(500).end('Error: Could not save contacts');
         } else {
-          response.status(200).send(docs);
+          response.status(200).end(docs);
         }
       });
     });


### PR DESCRIPTION
For some reason, the previous implementation didn't work, so I re-wrote it using a regular expression.

Before, when I tried to add contacts with non-numeric characters in their phone numbers, it would produce the following error in Node:

```
{ [ValidationError: Contact validation failed]
  message: 'Contact validation failed',
  name: 'ValidationError',
  errors: 
   { phone: 
      { [CastError: Cast to Number failed for value "NaN" at path "phone"]
        message: 'Cast to Number failed for value "NaN" at path "phone"',
        name: 'CastError',
        kind: 'Number',
        value: NaN,
        path: 'phone' } } }
```
